### PR TITLE
feat: upgrades spawn instances now + some necessary changes to classes

### DIFF
--- a/scenes/Room.tscn
+++ b/scenes/Room.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=11 format=3 uid="uid://c4prx7nk2xo4"]
+[gd_scene load_steps=10 format=3 uid="uid://c4prx7nk2xo4"]
 
 [ext_resource type="PackedScene" uid="uid://cqcldyqajw3yc" path="res://assets/buckshot_roulette_table_-_3d_model.glb" id="1_jn645"]
 [ext_resource type="PackedScene" uid="uid://lky204uemp8" path="res://scenes/gun.tscn" id="3_85yof"]
-[ext_resource type="Script" uid="uid://bv6skexvrv481" path="res://scripts/player.gd" id="3_ut7mc"]
 [ext_resource type="PackedScene" uid="uid://cn7iq23q16pu7" path="res://scenes/upgrade.tscn" id="4_jn645"]
 [ext_resource type="Script" uid="uid://drtpetyjiq1sf" path="res://scripts/gameManager.gd" id="4_jxe34"]
 [ext_resource type="PackedScene" uid="uid://bj53s6w12n7ya" path="res://scenes/player.tscn" id="6_eom3m"]
@@ -41,17 +40,15 @@ mesh = SubResource("PlaneMesh_ffxv4")
 
 [node name="Player1" parent="." instance=ExtResource("6_eom3m")]
 transform = Transform3D(-1.3113416e-09, 0, -0.03, 0, 0.03, 0, 0.03, 0, -1.3113416e-09, 3.3819137, 0.39279103, 4.446)
-script = ExtResource("3_ut7mc")
 
 [node name="Player2" parent="." instance=ExtResource("6_eom3m")]
 transform = Transform3D(-1.3113416e-09, 0, 0.03, 0, 0.03, 0, -0.03, 0, -1.3113416e-09, -2.615, 0.393, 4.435)
-script = ExtResource("3_ut7mc")
 
 [node name="Gun" parent="." instance=ExtResource("3_85yof")]
 transform = Transform3D(0.70710677, 0, 0.70710677, 0, 1, 0, -0.70710677, 0, 0.70710677, -0.25, 0, 4.5)
 
 [node name="Upgrade" parent="." instance=ExtResource("4_jn645")]
-transform = Transform3D(-1.0927847e-08, 0, 0.25, 0, 0.25, 0, -0.25, 0, -1.0927847e-08, 1.9140401, 0, 5.3526034)
+transform = Transform3D(-1.0927847e-08, 0, 0.25, 0, 0.25, 0, -0.25, 0, -1.0927847e-08, 1.9140401, -4.867008, 5.3526034)
 
 [node name="GameManager" type="Node" parent="."]
 script = ExtResource("4_jxe34")

--- a/scenes/Room.tscn
+++ b/scenes/Room.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://c4prx7nk2xo4"]
+[gd_scene load_steps=11 format=3 uid="uid://c4prx7nk2xo4"]
 
 [ext_resource type="PackedScene" uid="uid://cqcldyqajw3yc" path="res://assets/buckshot_roulette_table_-_3d_model.glb" id="1_jn645"]
 [ext_resource type="PackedScene" uid="uid://lky204uemp8" path="res://scenes/gun.tscn" id="3_85yof"]
+[ext_resource type="Script" uid="uid://bv6skexvrv481" path="res://scripts/player.gd" id="3_ut7mc"]
 [ext_resource type="PackedScene" uid="uid://cn7iq23q16pu7" path="res://scenes/upgrade.tscn" id="4_jn645"]
 [ext_resource type="Script" uid="uid://drtpetyjiq1sf" path="res://scripts/gameManager.gd" id="4_jxe34"]
 [ext_resource type="PackedScene" uid="uid://bj53s6w12n7ya" path="res://scenes/player.tscn" id="6_eom3m"]
@@ -40,9 +41,11 @@ mesh = SubResource("PlaneMesh_ffxv4")
 
 [node name="Player1" parent="." instance=ExtResource("6_eom3m")]
 transform = Transform3D(-1.3113416e-09, 0, -0.03, 0, 0.03, 0, 0.03, 0, -1.3113416e-09, 3.3819137, 0.39279103, 4.446)
+script = ExtResource("3_ut7mc")
 
 [node name="Player2" parent="." instance=ExtResource("6_eom3m")]
 transform = Transform3D(-1.3113416e-09, 0, 0.03, 0, 0.03, 0, -0.03, 0, -1.3113416e-09, -2.615, 0.393, 4.435)
+script = ExtResource("3_ut7mc")
 
 [node name="Gun" parent="." instance=ExtResource("3_85yof")]
 transform = Transform3D(0.70710677, 0, 0.70710677, 0, 1, 0, -0.70710677, 0, 0.70710677, -0.25, 0, 4.5)

--- a/scenes/mainScene.tscn
+++ b/scenes/mainScene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://c87m08lc0b3e4"]
 
 [ext_resource type="Script" uid="uid://caiabdo0cbleb" path="res://scripts/mainScene.gd" id="1_ki6c0"]
-[ext_resource type="PackedScene" uid="uid://c4prx7nk2xo4" path="res://scenes/room.tscn" id="2_8ifl6"]
+[ext_resource type="PackedScene" uid="uid://c4prx7nk2xo4" path="res://scenes/Room.tscn" id="2_8ifl6"]
 
 [node name="Root" type="Node"]
 script = ExtResource("1_ki6c0")

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://bj53s6w12n7ya"]
+[gd_scene load_steps=3 format=3 uid="uid://bj53s6w12n7ya"]
 
 [ext_resource type="PackedScene" uid="uid://3oofuonw05r8" path="res://assets/first_person_arms.glb" id="1_3vyb7"]
+[ext_resource type="Script" uid="uid://bv6skexvrv481" path="res://scripts/player.gd" id="1_g2els"]
 
 [node name="Player" type="Node3D"]
+script = ExtResource("1_g2els")
 
 [node name="ArmsMesh" parent="." instance=ExtResource("1_3vyb7")]
 

--- a/scenes/upgrade.tscn
+++ b/scenes/upgrade.tscn
@@ -1,13 +1,17 @@
-[gd_scene load_steps=4 format=3 uid="uid://cn7iq23q16pu7"]
+[gd_scene load_steps=5 format=3 uid="uid://cn7iq23q16pu7"]
 
 [ext_resource type="Script" uid="uid://dqu0gsp3o5sfv" path="res://scripts/upgrade.gd" id="1_xsw34"]
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_xsw34"]
+albedo_color = Color(1, 0, 1, 1)
+
 [sub_resource type="BoxMesh" id="BoxMesh_xsw34"]
+material = SubResource("StandardMaterial3D_xsw34")
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_xsw34"]
 
 [node name="Upgrade" type="Node3D"]
-transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, 0, 0, 0)
+transform = Transform3D(0.1, 0, 0, 0, 0.05, 0, 0, 0, 0.1, 0, 0, 0)
 script = ExtResource("1_xsw34")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/scripts/gameManager.gd
+++ b/scripts/gameManager.gd
@@ -2,7 +2,8 @@ extends Node
 
 # Initializing the game state
 var gameState: GameState = null
-@onready var players: Array[Player] = []
+var upgradeScene: PackedScene = null
+var players: Array[Player] = []
 var currPlayerTurnIndex: int = 0 
 var shotgunShells: Array[int] = [] # 0 for blank, 1 for live
 var roundIndex: int = 0
@@ -13,25 +14,27 @@ var realShots: int = 0;
 var blanks: int = 0;
 var maxHP: int = 3 # temporary value
 var isUpgradeRnd : bool = false # false means players can shoot, true means its upgrade pickup round
+var table: Node3D = null;
 # Game Logic functions
 func initMatch() -> void:
 	# add logic here to set up initial players and scene (can only really do this once the scene is done)
 	# scene work ig would need to be done to actually call this func
 	# one this fumc is called though a continuous match SHOULD work.
 	# as for UI changes and stuff best to have them as side effects of functions here i think.
+	upgradeScene = preload("res://scenes/upgrade.tscn")
 	roundIndex = 0
 	shotgunShellCount = 8
-	print(get_node("../Player1"))
 	players = [get_node("../Player1"), get_node("../Player2")]
-	print(players)
-	return;
 	gameState = GameState.new(players, [])
+	table = get_node("../Table")
 	initRound()
 
 func initRound() -> void:
+	
 	# figure out a way to randomly generate upgrade scenes and spawn them into the world
 	if roundIndex != 0:
 		generateRandomUpgrades() # doesnt work yet
+		spawnUpgradesOnTable()
 	
 	shotgunShellCount = initShotgunShellCount * (roundIndex + 1) # maybe give this more thought
 	# use real and blanks to show at the start of a round for a bit
@@ -41,7 +44,6 @@ func initRound() -> void:
 	if roundIndex != 0:
 		isUpgradeRnd = true
 	currPlayerTurnIndex = randi() % gameState.alivePlayers.size()
-	
 
 func endTurn() -> void:
 	if(shotgunShells.size() == 0):
@@ -51,6 +53,9 @@ func endTurn() -> void:
 	
 	currPlayerTurnIndex = (currPlayerTurnIndex + 1) % gameState.alivePlayers.size()
 	
+	if(isUpgradeRnd):
+		spawnUpgradesOnTable()
+		
 	if isUpgradeRnd && gameState.upgradesOnTable.size() == 0:
 		isUpgradeRnd = false
 		currPlayerTurnIndex -= 1
@@ -61,7 +66,9 @@ func endTurn() -> void:
 		
 		# now here would probably be a good time to flash the number of reals and blanks
 		 
-
+	# once all turn loggic is done with, send a signal to all players to refetch gameState
+	
+	
 	# maybe we could allow players to use upgrades like handcuffs during the upgrade pickup sesh?
 	while gameState.alivePlayers[currPlayerTurnIndex].isHandcuffed:
 		gameState.alivePlayers[currPlayerTurnIndex].isHandcuffed = false # in the actual buckshot roulette handcuffs are broken after a full circle of the skipped turn so might have to change this
@@ -92,8 +99,58 @@ func generateRandomBulletsOrder():
 			remainingBlank -= 1
 
 func generateRandomUpgrades():
-	# wait for enum ig
-	pass
+	# cleaned up jeff code 
+	gameState.upgradesOnTable.clear()
+	var numUpgrades = 8 * roundIndex
+	var availableTypes = []
+	if roundIndex == 1:
+		availableTypes = [
+			Upgrade.UpgradeType.cigarette,
+			Upgrade.UpgradeType.beer,
+			Upgrade.UpgradeType.magGlass
+		]
+	elif roundIndex == 2:
+		availableTypes = [
+			Upgrade.UpgradeType.cigarette,
+			Upgrade.UpgradeType.beer,
+			Upgrade.UpgradeType.magGlass,
+			Upgrade.UpgradeType.handSaw,
+			Upgrade.UpgradeType.handcuff
+		]
+	else:
+		availableTypes = Upgrade.UpgradeType.values()
+
+	for i in range(numUpgrades):
+		var randomType = availableTypes[randi() % availableTypes.size()]
+		var newUpgrade = Upgrade.new()
+		newUpgrade.upgrade_type = randomType
+		gameState.upgradesOnTable.append(newUpgrade)
+
+# curr plan is to recall this every upgrade turn
+func spawnUpgradesOnTable():
+	for child in table.get_children():
+		if child is Upgrade:
+			child.queue_free()
+	
+	# hopefully a square grid forms of side 1.5 1.5, temp for now 
+	var tableX : float = 1.5
+	var tableZ: float = 1.5
+	var columns : int = ceil(sqrt(gameState.upgradesOnTable.size()))
+	var rows : int = ceil(sqrt(gameState.upgradesOnTable.size()))
+	var spacingX = tableX/columns
+	var spacingZ = tableZ/rows
+	var startX = -0.5   # messy magic number offset temporary for now
+	var startZ = 4.5 # messy magic number offset temporary for now
+	
+	for i in range(gameState.upgradesOnTable.size()):
+		var upgradeInstance: Upgrade = upgradeScene.instantiate() as Upgrade
+		upgradeInstance.upgrade_type = gameState.upgradesOnTable[i].upgrade_type
+		var row = i/columns # how to disable stupid ass warning for int div
+		var col = i % columns
+		upgradeInstance.position = Vector3(startX + col * spacingX,  0.1, (startZ + row * spacingZ))
+		gameState.upgradesOnTable[i].pos = upgradeInstance.position
+		print(gameState.upgradesOnTable[i].pos)
+		table.add_child(upgradeInstance)
 
 # Below are all functions that are player facing, call these when designing players for player devs
 func endGame() -> void:
@@ -168,7 +225,8 @@ func useUpgrade(upgradeRef: Upgrade, callerPlayerRef: Player, targetPlayerRef: P
 			useDisableUpgrade(callerPlayerRef, targetPlayerRef)
 		Upgrade.UpgradeType.wildCard:
 			# Generating random upgrade from 0-7
-			var newUpgrade = Upgrade.new(Upgrade.UpgradeType.values()[randi() % 8])
+			var newUpgrade = Upgrade.new()
+			newUpgrade.upgrade_type = Upgrade.UpgradeType.values()[randi() % 8]
 			useUpgrade(newUpgrade, callerPlayerRef, targetPlayerRef)
 		
 	callerPlayerRef.inventory.erase(upgradeRef)

--- a/scripts/gameManager.gd
+++ b/scripts/gameManager.gd
@@ -1,8 +1,8 @@
 extends Node
 
 # Initializing the game state
-var gameState: GameState = GameState.new([], [])
-var players: Array[Player] = []
+var gameState: GameState = null
+@onready var players: Array[Player] = []
 var currPlayerTurnIndex: int = 0 
 var shotgunShells: Array[int] = [] # 0 for blank, 1 for live
 var roundIndex: int = 0
@@ -21,6 +21,11 @@ func initMatch() -> void:
 	# as for UI changes and stuff best to have them as side effects of functions here i think.
 	roundIndex = 0
 	shotgunShellCount = 8
+	print(get_node("../Player1"))
+	players = [get_node("../Player1"), get_node("../Player2")]
+	print(players)
+	return;
+	gameState = GameState.new(players, [])
 	initRound()
 
 func initRound() -> void:
@@ -213,3 +218,6 @@ func useUnoRev(callerPlayerRef: Player, targetPlayerRef: Player) -> void:
 
 func useDisableUpgrade(callerPlayerRef: Player, targetPlayerRef: Player) -> void:
 	pass
+	
+func _ready():
+	initMatch()  

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Node3D
 
 class_name Player
 

--- a/scripts/upgrade.gd
+++ b/scripts/upgrade.gd
@@ -4,6 +4,6 @@ enum UpgradeType {cigarette, beer, magGlass, handcuff, expiredMed, inverter,
 				  burnerPhone, handSaw, adrenaline, disableUpgrade, unoRev, wildCard}
 
 var upgrade_type: UpgradeType
-
-func _init(type: UpgradeType):
-	upgrade_type = type
+var pos: Vector3 # ts is for players to get pos of
+# ts wasn't working when isntantiating so i removed _init
+	


### PR DESCRIPTION
Godot is weird it kept throwing errors when trying to instantiate as Upgrade and i think this is because it has an _init(), but couldnt find a way to pass in constructor params either.  Anyway added a pos and removed constructor to upgrade, upgrades now spawn during upgrade rounds in a weird square way (prototype). Picking upgrades requires missing player functionality so waiting on adi pranav